### PR TITLE
#9 fix bug where can't add same frontContent for two different languages

### DIFF
--- a/lib/services/card_cubit.dart
+++ b/lib/services/card_cubit.dart
@@ -34,7 +34,8 @@ class CardCubit extends Cubit<List<database_model.Card>> {
     String? pronunciation,
     String? exampleUsage,
   }) async {
-    final bool cardMatch = await dBService.checkCardMatch(frontContent);
+    final bool cardMatch =
+        await dBService.checkCardMatch(frontContent, language);
 
     !cardMatch
         ? await dBService.createCard(

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -88,10 +88,14 @@ class DatabaseService {
         .get();
   }
 
-  Future<bool> checkCardMatch(String frontContent) async {
+  Future<bool> checkCardMatch(String frontContent, String language) async {
+    final int langID = await getLangID(language);
+
     final Card? cardMatch = await (dB.select(dB.cards)
           ..where(
-            (tbl) => tbl.frontContent.equals(frontContent),
+            (tbl) =>
+                tbl.frontContent.equals(frontContent) &
+                tbl.language.equals(langID),
           ))
         .getSingleOrNull();
     return cardMatch != null;

--- a/test/card_cubit_test.dart
+++ b/test/card_cubit_test.dart
@@ -16,7 +16,8 @@ void main() {
     final mock = MockDatabaseService();
     when(() => mock.getAllCards())
         .thenAnswer((_) async => <database_model.Card>[]);
-    when(() => mock.checkCardMatch(any())).thenAnswer((_) async => false);
+    when(() => mock.checkCardMatch(any(), any()))
+        .thenAnswer((_) async => false);
     when(
       () => mock.createCard(
         language: any(named: 'language'),
@@ -69,7 +70,7 @@ void main() {
     final mock = MockDatabaseService();
     when(() => mock.getAllCards())
         .thenAnswer((_) async => <database_model.Card>[]);
-    when(() => mock.checkCardMatch(any())).thenAnswer((_) async => true);
+    when(() => mock.checkCardMatch(any(), any())).thenAnswer((_) async => true);
     when(() => mock.getCardsOfLang(any()))
         .thenAnswer((_) async => <database_model.Card>[]);
 


### PR DESCRIPTION
Fixed an issue with checkCardMatch function, preventing user from having the same frontContent on cards in multiple languages.